### PR TITLE
feat(cli) add input dedup, --no-cache flag, and subcommand fallback

### DIFF
--- a/cli/cli/src/cmd/packument/fetch-list.js
+++ b/cli/cli/src/cmd/packument/fetch-list.js
@@ -43,18 +43,48 @@ function parseTextFile(filepath) {
 }
 
 /**
+ * Extract unique package names from a parsed list.
+ * Handles both plain strings and {name, ...} objects.
+ * @param {Array<string|{name: string}>} items - Raw items from input
+ * @returns {string[]} Deduplicated array of package names
+ */
+function uniqueNames(items) {
+  const seen = new Set();
+  const names = [];
+
+  for (const item of items) {
+    const name = typeof item === 'string' ? item
+      : (item && typeof item.name === 'string') ? item.name
+      : null;
+
+    if (!name) {
+      console.warn(`Warning: Skipping unrecognized entry: ${JSON.stringify(item)}`);
+      continue;
+    }
+
+    if (!seen.has(name)) {
+      seen.add(name);
+      names.push(name);
+    }
+  }
+
+  return names;
+}
+
+/**
  * Load package names from input file
  * @param {string} fullpath - Absolute path to input file
- * @returns {Promise<string[]>} Array of package names
+ * @returns {Promise<string[]>} Deduplicated array of package names
  */
 async function loadPackageNames(fullpath) {
   const ext = extname(fullpath).toLowerCase();
 
   if (ext === '.json') {
     const { default: jsonData } = await import(fullpath, { with: { type: 'json' } });
-    return Array.isArray(jsonData) ? jsonData : [jsonData];
+    const items = Array.isArray(jsonData) ? jsonData : [jsonData];
+    return uniqueNames(items);
   } else if (ext === '.txt' || ext === '.text' || ext === '') {
-    return parseTextFile(fullpath);
+    return uniqueNames(parseTextFile(fullpath));
   } else {
     throw new Error(`Unsupported file type: ${ext}. Use .json or .txt files.`);
   }
@@ -211,6 +241,10 @@ export const command = async cli => {
     env
   });
 
+  // Resolve cache flag: --no-cache sets cli.values.cache to false
+  const useCache = cli.values.cache !== false;
+  const requestOptions = useCache ? {} : { cache: false };
+
   // Track progress with atomic counter for concurrent access
   let processedCount = 0;
   let interrupted = false;
@@ -247,7 +281,7 @@ export const command = async cli => {
       }
 
       try {
-        const entry = await client.request(name);
+        const entry = await client.request(name, requestOptions);
         const cached = entry?.hit ?? false;
 
         if (useCheckpoint) {

--- a/cli/cli/src/index.js
+++ b/cli/cli/src/index.js
@@ -52,14 +52,31 @@ async function importCommand(cmd, subcmd) {
     process.exit(1);
   }
 
-  const cmdpath = `${cmd}/${subcmd}`;
+  if (subcmd) {
+    const cmdpath = `${cmd}/${subcmd}`;
+    try {
+      return await import(`./cmd/${cmdpath}.js`);
+    } catch (err) {
+      throw error('Failed to load command', {
+        found: cmdpath,
+        cause: err
+      });
+    }
+  }
+
+  // No subcommand provided: try loading the command's index module
   try {
-    return await import(`./cmd/${cmdpath}.js`);
-  } catch (err) {
-    throw error('Failed to load command', {
-      found: cmdpath,
-      cause: err
-    });
+    return await import(`./cmd/${cmd}/index.js`);
+  } catch {
+    // No index.js exists for this command; return a stub so --help
+    // can still print general CLI usage via output.js fallback
+    return {
+      command: () => {
+        console.error(`Error: No subcommand provided for '${cmd}'`);
+        console.error(cli.usage());
+        process.exit(1);
+      }
+    };
   }
 }
 


### PR DESCRIPTION
## What

Adds a `uniqueNames()` helper to `cli/cli/src/cmd/packument/fetch-list.js` that deduplicates package names parsed from JSON and text input files, handling both plain string entries and `{name, ...}` objects. The existing `--no-cache` CLI flag is wired through to the packument client by constructing `requestOptions` from `cli.values.cache`. `importCommand` in `cli/cli/src/index.js` is refactored to gracefully handle invocations without a subcommand — it first attempts to load a command-level `index.js` module before falling back to an informative usage error.

## Why

### Input deduplication

`loadPackageNames` previously returned raw items verbatim, so duplicate entries in an input file caused redundant fetches. JSON inputs could also contain `{name: "..."}` objects instead of bare strings, which would silently pass through as non-string values. `uniqueNames()` normalizes both shapes, warns on unrecognized entries, and deduplicates via a `Set`.

### `--no-cache` passthrough

The `--no-cache` flag was accepted by the argument parser but never forwarded to `client.request()`. The new `requestOptions` object conditionally sets `{ cache: false }` when the flag is present, so cache-busting actually takes effect.

### Subcommand fallback

`importCommand` previously required both a command and subcommand, throwing an opaque import error when only a top-level command was given. The refactored version tries `./cmd/${cmd}/index.js` first and, if no index module exists, prints a clear "no subcommand provided" message with CLI usage before exiting.

## Risk Assessment

**Low risk:** All changes are additive. The dedup helper is a pure function. The `--no-cache` wiring only activates when the flag is explicitly passed. The `importCommand` refactor preserves the existing two-argument path unchanged and only adds a new fallback branch.
